### PR TITLE
Not activated account message when isEnabled = false for new employees

### DIFF
--- a/src/main/java/com/project/Onlineshop/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/Onlineshop/UserDetailsServiceImpl.java
@@ -6,6 +6,7 @@ import com.project.Onlineshop.Repository.EmployeeRepository;
 import com.project.Onlineshop.Repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -52,6 +53,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private UserDetails loadEmployeeByEmailOrUsername(String emailOrUsername) {
         Optional<Employee> optionalEmployee = employeeRepository.findByEmail(emailOrUsername);
         if (optionalEmployee.isPresent()) {
+            if (!optionalEmployee.get().isEnabled()) {
+                throw new DisabledException("User is not enabled");
+            }
             return new MyUserDetails(optionalEmployee.get());
         }
         optionalEmployee = employeeRepository.findByUsername(emailOrUsername);

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -10,9 +10,13 @@
 
 <div class="col-6 container flex-grow-1 mt-5 mb-5">
     <div th:if="${param.error}">
-        <p class="alert alert-danger text-center">Invalid username or password.</p>
+        <p th:if="${session.SPRING_SECURITY_LAST_EXCEPTION.message == 'User is disabled'}"
+           class="alert alert-danger text-center">Your account needs to be approved by an admin first!
+        </p>
+        <p th:if="${session.SPRING_SECURITY_LAST_EXCEPTION.message != 'User is disabled'}"
+           class="alert alert-danger text-center">Invalid username or password.
+        </p>
     </div>
-
     <div th:if="${param.loggedOut}">
         <p class="alert alert-success text-center">You have logged out successfully.</p>
     </div>


### PR DESCRIPTION
Now if an employee account is created and it's tried to be logged in with it, the login form will display a message saying that it needs to be activated by an admin first.